### PR TITLE
Rename scraper actions

### DIFF
--- a/app/app/Actions/ScrapeDocumentInfoAction.php
+++ b/app/app/Actions/ScrapeDocumentInfoAction.php
@@ -4,11 +4,11 @@ namespace App\Actions;
 
 use App\Document;
 
-class ScrapeAndSaveDocumentInfoAction extends Action
+class ScrapeDocumentInfoAction extends Action
 {
     private $scrapeAction;
 
-    public function __construct(ScrapeAction $scrapeAction, ScrapeAndSaveProcedureAction $scrapeProcedureAction)
+    public function __construct(ScrapeAction $scrapeAction, ScrapeProcedureAction $scrapeProcedureAction)
     {
         $this->scrapeAction = $scrapeAction;
         $this->scrapeProcedureAction = $scrapeProcedureAction;

--- a/app/app/Actions/ScrapeMemberGroupsAction.php
+++ b/app/app/Actions/ScrapeMemberGroupsAction.php
@@ -7,7 +7,7 @@ use App\GroupMembership;
 use App\Member;
 use App\Term;
 
-class ScrapeAndSaveMemberGroupsAction extends Action
+class ScrapeMemberGroupsAction extends Action
 {
     private $scrapeAction;
 

--- a/app/app/Actions/ScrapeMemberInfoAction.php
+++ b/app/app/Actions/ScrapeMemberInfoAction.php
@@ -5,7 +5,7 @@ namespace App\Actions;
 use App\Enums\CountryEnum;
 use App\Member;
 
-class ScrapeAndSaveMemberInfoAction extends Action
+class ScrapeMemberInfoAction extends Action
 {
     private $scrapeAction;
 

--- a/app/app/Actions/ScrapeMembersAction.php
+++ b/app/app/Actions/ScrapeMembersAction.php
@@ -5,7 +5,7 @@ namespace App\Actions;
 use App\Member;
 use App\Term;
 
-class ScrapeAndSaveMembersAction extends Action
+class ScrapeMembersAction extends Action
 {
     private $scrapeAction;
 

--- a/app/app/Actions/ScrapeProcedureAction.php
+++ b/app/app/Actions/ScrapeProcedureAction.php
@@ -5,7 +5,7 @@ namespace App\Actions;
 use App\Document;
 use App\Procedure;
 
-class ScrapeAndSaveProcedureAction extends Action
+class ScrapeProcedureAction extends Action
 {
     private $scrapeAction;
 

--- a/app/app/Actions/ScrapeVoteResultsAction.php
+++ b/app/app/Actions/ScrapeVoteResultsAction.php
@@ -11,12 +11,12 @@ use App\Vote;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
-class ScrapeAndSaveVoteResultsAction extends Action
+class ScrapeVoteResultsAction extends Action
 {
     private $scrapeAction;
     private $documentInfoAction;
 
-    public function __construct(ScrapeAction $scrapeAction, ScrapeAndSaveDocumentInfoAction $documentInfoAction)
+    public function __construct(ScrapeAction $scrapeAction, ScrapeDocumentInfoAction $documentInfoAction)
     {
         $this->scrapeAction = $scrapeAction;
         $this->documentInfoAction = $documentInfoAction;

--- a/app/app/Providers/AppServiceProvider.php
+++ b/app/app/Providers/AppServiceProvider.php
@@ -3,16 +3,9 @@
 namespace App\Providers;
 
 use App\Actions\ScrapeAction;
-use App\Actions\ScrapeDocumentInfoAction;
-use App\Actions\ScrapeMemberGroupsAction;
-use App\Actions\ScrapeMemberInfoAction;
-use App\Actions\ScrapeMembersAction;
-use App\Actions\ScrapeVoteResultsAction;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -30,14 +23,6 @@ class AppServiceProvider extends ServiceProvider
                 config('scrapers.port')
             );
         });
-
-        $this->app->bind(ScrapeMembersAction::class);
-        $this->app->bind(ScrapeMemberInfoAction::class);
-        $this->app->bind(ScrapeMemberGroupsAction::class);
-        $this->app->bind(ScrapeDocumentInfoAction::class);
-        $this->app->bind(ScrapeVoteResultsAction::class);
-
-        $this->app->bind(CompileVoteStatsAction::class);
     }
 
     /**

--- a/app/app/Providers/AppServiceProvider.php
+++ b/app/app/Providers/AppServiceProvider.php
@@ -46,14 +46,6 @@ class AppServiceProvider extends ServiceProvider
             ]);
         });
 
-        // DB::listen(function ($query) {
-        //     Log::info(
-        //         $query->sql,
-        //         $query->bindings,
-        //         $query->time
-        //     );
-        // });
-
         Collection::macro('toAssoc', function () {
             return $this->reduce(function ($assoc, $keyValuePair) {
                 [$key, $value] = $keyValuePair;

--- a/app/app/Providers/AppServiceProvider.php
+++ b/app/app/Providers/AppServiceProvider.php
@@ -3,11 +3,11 @@
 namespace App\Providers;
 
 use App\Actions\ScrapeAction;
-use App\Actions\ScrapeAndSaveDocumentInfoAction;
-use App\Actions\ScrapeAndSaveMemberGroupsAction;
-use App\Actions\ScrapeAndSaveMemberInfoAction;
-use App\Actions\ScrapeAndSaveMembersAction;
-use App\Actions\ScrapeAndSaveVoteResultsAction;
+use App\Actions\ScrapeDocumentInfoAction;
+use App\Actions\ScrapeMemberGroupsAction;
+use App\Actions\ScrapeMemberInfoAction;
+use App\Actions\ScrapeMembersAction;
+use App\Actions\ScrapeVoteResultsAction;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
@@ -31,11 +31,11 @@ class AppServiceProvider extends ServiceProvider
             );
         });
 
-        $this->app->bind(ScrapeAndSaveMembersAction::class);
-        $this->app->bind(ScrapeAndSaveMemberInfoAction::class);
-        $this->app->bind(ScrapeAndSaveMemberGroupsAction::class);
-        $this->app->bind(ScrapeAndSaveDocumentInfoAction::class);
-        $this->app->bind(ScrapeAndSaveVoteResultsAction::class);
+        $this->app->bind(ScrapeMembersAction::class);
+        $this->app->bind(ScrapeMemberInfoAction::class);
+        $this->app->bind(ScrapeMemberGroupsAction::class);
+        $this->app->bind(ScrapeDocumentInfoAction::class);
+        $this->app->bind(ScrapeVoteResultsAction::class);
 
         $this->app->bind(CompileVoteStatsAction::class);
     }

--- a/app/routes/console.php
+++ b/app/routes/console.php
@@ -1,10 +1,10 @@
 <?php
 
 use App\Actions\CompileVoteStatsAction;
-use App\Actions\ScrapeAndSaveMemberGroupsAction;
-use App\Actions\ScrapeAndSaveMemberInfoAction;
-use App\Actions\ScrapeAndSaveMembersAction;
-use App\Actions\ScrapeAndSaveVoteResultsAction;
+use App\Actions\ScrapeMemberGroupsAction;
+use App\Actions\ScrapeMemberInfoAction;
+use App\Actions\ScrapeMembersAction;
+use App\Actions\ScrapeVoteResultsAction;
 use App\Member;
 use App\Term;
 use App\Vote;
@@ -29,7 +29,7 @@ Artisan::command('inspire', function () {
 
 Artisan::command('scrape:members {term}', function (
     int $term,
-    ScrapeAndSaveMembersAction $action
+    ScrapeMembersAction $action
 ) {
     $term = Term::whereNumber($term)->first();
     $this->info("Scraping list of members for term {$term}");
@@ -37,7 +37,7 @@ Artisan::command('scrape:members {term}', function (
     $action->execute($term);
 })->describe('Scrape and save all members (without info) for a given term.');
 
-Artisan::command('scrape:members-info', function (ScrapeAndSaveMemberInfoAction $action) {
+Artisan::command('scrape:members-info', function (ScrapeMemberInfoAction $action) {
     $allMembers = Member::all();
     $membersCount = $allMembers->count();
 
@@ -53,7 +53,7 @@ Artisan::command('scrape:members-info', function (ScrapeAndSaveMemberInfoAction 
 
 Artisan::command('scrape:members-groups {term}', function (
     int $term,
-    ScrapeAndSaveMemberGroupsAction $action
+    ScrapeMemberGroupsAction $action
 ) {
     $term = Term::whereNumber($term)->first();
     $allMembers = Member::all();
@@ -72,7 +72,7 @@ Artisan::command('scrape:members-groups {term}', function (
 Artisan::command('scrape:vote-results {term} {date}', function (
     int $term,
     string $date,
-    ScrapeAndSaveVoteResultsAction $action,
+    ScrapeVoteResultsAction $action,
     CompileVoteStatsAction $statsAction
 ) {
     $term = Term::whereNumber($term)->first();

--- a/app/tests/Unit/Actions/ScrapeDocumentInfoActionTest.php
+++ b/app/tests/Unit/Actions/ScrapeDocumentInfoActionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Actions\ScrapeAndSaveDocumentInfoAction;
+use App\Actions\ScrapeDocumentInfoAction;
 use App\Document;
 use App\Enums\DocumentTypeEnum;
 use App\Procedure;
@@ -23,7 +23,7 @@ beforeEach(function () {
 });
 
 it('updates document data', function () {
-    $this->action = $this->app->make(ScrapeAndSaveDocumentInfoAction::class);
+    $this->action = $this->app->make(ScrapeDocumentInfoAction::class);
     $this->action->execute($this->document);
 
     $title = $this->document->fresh()->title;
@@ -33,7 +33,7 @@ it('updates document data', function () {
 });
 
 it('creates related procedure record', function () {
-    $this->action = $this->app->make(ScrapeAndSaveDocumentInfoAction::class);
+    $this->action = $this->app->make(ScrapeDocumentInfoAction::class);
     $this->action->execute($this->document);
 
     expect(Procedure::count())->toEqual(1);

--- a/app/tests/Unit/Actions/ScrapeMemberGroupsActionTest.php
+++ b/app/tests/Unit/Actions/ScrapeMemberGroupsActionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Actions\ScrapeAndSaveMemberGroupsAction;
+use App\Actions\ScrapeMemberGroupsAction;
 use App\Group;
 use App\GroupMembership;
 use App\Member;
@@ -10,7 +10,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(Tests\TestCase::class, RefreshDatabase::class);
 
 beforeEach(function () {
-    $this->action = $this->app->make(ScrapeAndSaveMemberGroupsAction::class);
+    $this->action = $this->app->make(ScrapeMemberGroupsAction::class);
 
     $this->member = Member::factory(['web_id' => 12345])->create();
     $this->group = Group::factory(['code' => 'GREENS'])->create();

--- a/app/tests/Unit/Actions/ScrapeMemberInfoActionTest.php
+++ b/app/tests/Unit/Actions/ScrapeMemberInfoActionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Actions\ScrapeAndSaveMemberInfoAction;
+use App\Actions\ScrapeMemberInfoAction;
 use App\Enums\CountryEnum;
 use App\Member;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -9,7 +9,7 @@ use Illuminate\Support\Arr;
 uses(Tests\TestCase::class, RefreshDatabase::class);
 
 it('updates member data', function () {
-    $this->action = $this->app->make(ScrapeAndSaveMemberInfoAction::class);
+    $this->action = $this->app->make(ScrapeMemberInfoAction::class);
     Http::fakeJsonFromFile('*/member_info?web_id=12345', 'member_info.json');
 
     $member = Member::factory(['web_id' => 12345])->create();

--- a/app/tests/Unit/Actions/ScrapeMembersActionTest.php
+++ b/app/tests/Unit/Actions/ScrapeMembersActionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Actions\ScrapeAndSaveMembersAction;
+use App\Actions\ScrapeMembersAction;
 use App\Member;
 use App\Term;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(Tests\TestCase::class, RefreshDatabase::class);
 
 beforeEach(function () {
-    $this->action = $this->app->make(ScrapeAndSaveMembersAction::class);
+    $this->action = $this->app->make(ScrapeMembersAction::class);
     $this->term = Term::factory(['number' => 9])->create();
     Http::fakeJsonFromFile('*/members?term=9', 'members.json');
 });

--- a/app/tests/Unit/Actions/ScrapeProcedureActionTest.php
+++ b/app/tests/Unit/Actions/ScrapeProcedureActionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Actions\ScrapeAndSaveProcedureAction;
+use App\Actions\ScrapeProcedureAction;
 use App\Document;
 use App\Enums\DocumentTypeEnum;
 use App\Enums\ProcedureTypeEnum;
@@ -23,7 +23,7 @@ beforeEach(function () {
 });
 
 it('scrapes the procedure for a document', function () {
-    $this->action = $this->app->make(ScrapeAndSaveProcedureAction::class);
+    $this->action = $this->app->make(ScrapeProcedureAction::class);
     $procedure = $this->action->execute($this->document);
 
     $expected = [
@@ -47,7 +47,7 @@ it('does not create duplicates of an already existing procedure', function () {
 
     $this->document->update(['procedure_id' => $existingProcedure->id]);
 
-    $this->action = $this->app->make(ScrapeAndSaveProcedureAction::class);
+    $this->action = $this->app->make(ScrapeProcedureAction::class);
     $procedure = $this->action->execute($this->document);
 
     expect($procedure->id)->toEqual($existingProcedure->id);

--- a/app/tests/Unit/Actions/ScrapeVoteResultsActionTest.php
+++ b/app/tests/Unit/Actions/ScrapeVoteResultsActionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Actions\ScrapeAndSaveVoteResultsAction;
+use App\Actions\ScrapeVoteResultsAction;
 use App\Document;
 use App\Enums\DocumentTypeEnum;
 use App\Enums\VotePositionEnum;
@@ -14,11 +14,11 @@ use Illuminate\Support\Carbon;
 uses(Tests\TestCase::class, RefreshDatabase::class);
 
 beforeEach(function () {
-    //TODO: use dep injection to mock ScrapeAndSaveDocumentInfoAction
+    //TODO: use dep injection to mock ScrapeDocumentInfoAction
     Http::fakeJsonFromFile('*/document_info?type=B&term=9&number=154&year=2019', 'document_info.json');
     Http::fakeJsonFromFile('*/procedure?type=B&term=9&number=154&year=2019', 'procedure.json');
 
-    $this->action = $this->app->make(ScrapeAndSaveVoteResultsAction::class);
+    $this->action = $this->app->make(ScrapeVoteResultsAction::class);
     $this->term = Term::factory(['number' => 9])->create();
     $this->date = new Carbon('2019-10-24');
 });


### PR DESCRIPTION
Remove redundant “and save” from action names