### PR TITLE
Weekly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/scrapers"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "docker"
     directory: "/scrapers"
     schedule:
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "composer"
     directory: "/app"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "docker"
     directory: "/app"
     schedule:


### PR DESCRIPTION
Right now, Dependabot checks for updates of PHP and Python packages every day. That’s a little annoying and tbh it’s not really important that we’re always on the latest minor version of every package. I updated the Dependabot settings to check for updates on a weekly basis from now on. (We’ll still be notified of critical updates/security patches out of schedule.)