### PR TITLE
Fix cronjob error

### DIFF
--- a/app/app/Console/Kernel.php
+++ b/app/app/Console/Kernel.php
@@ -28,7 +28,7 @@ class Kernel extends ConsoleKernel
         $date = Carbon::today()->toDateString();
         $schedule->command("scrape:vote-results --term=9 --date {$date}")->dailyAt('21:00');
         $schedule->command('scrape:members --term=9')->weeklyOn(0, '18:00');
-        $schedule->command('scrape:members-info --term=9')->weeklyOn(0, '19:00');
+        $schedule->command('scrape:members-info')->weeklyOn(0, '19:00');
         $schedule->command('scrape:members-groups --term=9')->weeklyOn(0, '20:00');
     }
 


### PR DESCRIPTION
The `scrape:members-info` command doesn’t accept a `--term` option (because the scraped information doesn’t depend on the parliamentary term).

Close #199