### PR TITLE
Set Google FLoC opt out header

### DIFF
--- a/ansible/roles/setup/tasks/main.yml
+++ b/ansible/roles/setup/tasks/main.yml
@@ -25,3 +25,6 @@
       file:
         path: "{{ ansible_facts.env.HOME }}/get-poetry.py"
         state: absent
+
+- name: Setup Google FLoC opt out header
+  command: "uberspace web header set / Permissions-Policy \"interest-cohort=()\""


### PR DESCRIPTION
As described [here](https://github.com/WICG/floc#opting-out-of-computation) website administrators can opt-out of Google’s new Federated Learning of Cohorts using a Permissions-Policy header. Sites that set the header won’t be included in the cohort calculation.

Closes #241