### PR TITLE
Selector assertions

### DIFF
--- a/app/app/Mixins/AbstractRenderedMixin.php
+++ b/app/app/Mixins/AbstractRenderedMixin.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Mixins;
+
+use DOMDocument;
+use DOMXPath;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Illuminate\Testing\Assert;
+use Symfony\Component\CssSelector\CssSelectorConverter;
+
+abstract class AbstractRenderedMixin
+{
+    abstract public function getRenderedHTML();
+
+    public function select()
+    {
+        return function (string $selector): Collection {
+            // TODO: Explain why we need to internalize/ignore errors
+            libxml_use_internal_errors(true);
+
+            $document = new DOMDocument();
+            $document->loadHTML($this->getRenderedHTML());
+
+            $converter = new CssSelectorConverter();
+            $xPathSelector = $converter->toXPath($selector);
+
+            $xPath = new DOMXPath($document);
+            $elements = $xPath->query($xPathSelector);
+
+            return collect($elements);
+        };
+    }
+
+    public function assertSelector()
+    {
+        return function (string $selector, ?int $count = null): self {
+            $elements = $this->select($selector);
+            $actualCount = $elements->count();
+
+            Assert::assertTrue(
+                $elements->isNotEmpty(),
+                "Did not find '{$selector}'."
+            );
+
+            if ($count !== null) {
+                Assert::assertEquals(
+                    $count,
+                    $actualCount,
+                    "Expected to find '{$selector}' ${count} times, but found only {$actualCount} matching elements."
+                );
+            }
+
+            return $this;
+        };
+    }
+
+    public function assertSelectorText()
+    {
+        return function (string $selector, string $text, ?int $count = null): self {
+            $elements = $this
+                ->select($selector)
+                ->filter(fn ($element) => Str::contains($element->textContent, $text));
+
+            $actualCount = $elements->count();
+
+            Assert::assertTrue(
+                $elements->isNotEmpty(),
+                "Did not find '{$selector}' with text '{$text}'."
+            );
+
+            if ($count !== null) {
+                Assert::assertEquals(
+                    $count,
+                    $actualCount,
+                    "Expected to find '{$selector}' with text '{$text}' {$count} times, but found only {$actualCount} matching elements."
+                );
+            }
+
+            return $this;
+        };
+    }
+}

--- a/app/app/Mixins/TestResponseMixin.php
+++ b/app/app/Mixins/TestResponseMixin.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Mixins;
+
+class TestResponseMixin extends AbstractRenderedMixin
+{
+    public function getRenderedHTML()
+    {
+        return function (): string {
+            return $this->getContent();
+        };
+    }
+}

--- a/app/app/Mixins/TestViewMixin.php
+++ b/app/app/Mixins/TestViewMixin.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Mixins;
+
+class TestViewMixin extends AbstractRenderedMixin
+{
+    public function getRenderedHTML()
+    {
+        return function (): string {
+            return $this->rendered;
+        };
+    }
+}

--- a/app/app/Providers/AppServiceProvider.php
+++ b/app/app/Providers/AppServiceProvider.php
@@ -5,10 +5,14 @@ namespace App\Providers;
 use App\Actions\ScrapeAction;
 use App\Mixins\CollectionMixin;
 use App\Mixins\ComponentAttributeBagMixin;
+use App\Mixins\TestResponseMixin;
+use App\Mixins\TestViewMixin;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Testing\TestResponse;
+use Illuminate\Testing\TestView;
 use Illuminate\View\ComponentAttributeBag;
 
 class AppServiceProvider extends ServiceProvider
@@ -51,5 +55,7 @@ class AppServiceProvider extends ServiceProvider
 
         Collection::mixin(new CollectionMixin);
         ComponentAttributeBag::mixin(new ComponentAttributeBagMixin);
+        TestView::mixin(new TestViewMixin);
+        TestResponse::mixin(new TestResponseMixin);
     }
 }

--- a/app/composer.json
+++ b/app/composer.json
@@ -18,6 +18,7 @@
         "sentry/sentry-laravel": "^2.4",
         "spatie/laravel-enum": "^2",
         "spatie/url": "^2.0",
+        "symfony/css-selector": "^5.2",
         "vinkla/hashids": "^9.1"
     },
     "require-dev": {

--- a/app/composer.lock
+++ b/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2eeda7b8b9ccfb9eab1bbe480f9a467",
+    "content-hash": "1b059676c0dc8d59e2c07053ae7f5e03",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/app/tests/Feature/Http/Monitoring/IndexTest.php
+++ b/app/tests/Feature/Http/Monitoring/IndexTest.php
@@ -14,5 +14,5 @@ it('display voting lists without associated vote', function () {
 
     $response = $this->get('/monitoring');
 
-    expect($response)->toSee('1 - Unmatched Voting List');
+    expect($response)->toHaveSelectorWithText('li', '1 - Unmatched Voting List');
 });

--- a/app/tests/Feature/Http/VotingLists/ShowTest.php
+++ b/app/tests/Feature/Http/VotingLists/ShowTest.php
@@ -50,24 +50,24 @@ it('does not fail if there is no associated vote', function () {
 
 it('shows a title', function () {
     $response = $this->get('/votes/1');
-    expect($response)->toSeeText('My Title');
+    expect($response)->toHaveSelectorWithText('h1', 'My Title');
 });
 
 it('shows the result of the vote', function () {
     $response = $this->get('/votes/1');
-    expect($response)->toSee('adopted');
-    expect($response)->toSee('thumb--adopted thumb--circle');
+    expect($response)->toHaveSelectorWithText('h1 + p', 'adopted');
+    expect($response)->toHaveSelector('h1 + p > .thumb--adopted.thumb--circle');
 });
 
 it('displays a bar chart', function () {
     $response = $this->get('/votes/1');
-    expect($response)->toSee('vote-result-chart');
+    expect($response)->toHaveSelector('.vote-result-chart');
 });
 
 it('shows a list of members', function () {
     $response = $this->get('/votes/1');
-    expect($response)->toSeeText('Greens/EFA');
-    expect($response)->toSeeText('Jane DOE');
-    expect($response)->toSee('thumb--for thumb--circle list-item__thumb');
-    expect($response)->toSeeText('Netherlands');
+
+    expect($response)->toHaveSelectorWithText('.list-item__text', 'Jane DOE');
+    expect($response)->toHaveSelectorWithText('.list-item__text', 'Greens/EFA · Netherlands');
+    expect($response)->toHaveSelector('.thumb--for.thumb--circle.list-item__thumb');
 });

--- a/app/tests/Pest.php
+++ b/app/tests/Pest.php
@@ -19,3 +19,11 @@ expect()->extend('toSeeTextInOrder', function (array $texts) {
 expect()->extend('toHaveStatus', function (int $code) {
     return $this->value->assertStatus($code);
 });
+
+expect()->extend('toHaveSelector', function (string $selector, ?int $count = null) {
+    return $this->value->assertSelector($selector, $count);
+});
+
+expect()->extend('toHaveSelectorWithText', function (string $selector, string $text, ?int $count = null) {
+    return $this->value->assertSelectorText($selector, $text, $count);
+});

--- a/app/tests/Unit/Components/ThumbTest.php
+++ b/app/tests/Unit/Components/ThumbTest.php
@@ -7,43 +7,43 @@ uses(Tests\TestCase::class);
 
 it('accepts and maps result enums', function () {
     $view = $this->blade('<x-thumb :result="$result" />', ['result' => VoteResultEnum::ADOPTED()]);
-    expect($view)->toSee('thumb--adopted');
+    expect($view)->toHaveSelector('.thumb--adopted');
 
     $view = $this->blade('<x-thumb :result="$result" />', ['result' => VoteResultEnum::REJECTED()]);
-    expect($view)->toSee('thumb--rejected');
+    expect($view)->toHaveSelector('.thumb--rejected');
 });
 
 it('accepts and maps result string', function () {
     $view = $this->blade('<x-thumb result="adopted" />');
-    expect($view)->toSee('thumb--adopted');
+    expect($view)->toHaveSelector('.thumb--adopted');
 
     $view = $this->blade('<x-thumb result="rejected" />');
-    expect($view)->toSee('thumb--rejected');
+    expect($view)->toHaveSelector('.thumb--rejected');
 });
 
 it('accepts and maps position enums', function () {
     $view = $this->blade('<x-thumb :position="$position" />', ['position' => VotePositionEnum::FOR()]);
-    expect($view)->toSee('thumb--for');
+    expect($view)->toHaveSelector('.thumb--for');
 
     $view = $this->blade('<x-thumb :position="$position" />', ['position' => VotePositionEnum::AGAINST()]);
-    expect($view)->toSee('thumb--against');
+    expect($view)->toHaveSelector('.thumb--against');
 
     $view = $this->blade('<x-thumb :position="$position" />', ['position' => VotePositionEnum::ABSTENTION()]);
-    expect($view)->toSee('thumb--abstention');
+    expect($view)->toHaveSelector('.thumb--abstention');
 });
 
 it('accepts and maps position strings', function () {
     $view = $this->blade('<x-thumb position="for" />');
-    expect($view)->toSee('thumb--for');
+    expect($view)->toHaveSelector('.thumb--for');
 
     $view = $this->blade('<x-thumb result="against" />');
-    expect($view)->toSee('thumb--against');
+    expect($view)->toHaveSelector('.thumb--against');
 
     $view = $this->blade('<x-thumb position="abstention" />');
-    expect($view)->toSee('thumb--abstention');
+    expect($view)->toHaveSelector('.thumb--abstention');
 });
 
 it('accepts circle as a style modifier', function () {
     $view = $this->blade('<x-thumb position="for" style="circle" />');
-    expect($view)->toSee('thumb--circle');
+    expect($view)->toHaveSelector('.thumb--circle');
 });

--- a/app/tests/Unit/Components/VoteResultChartBarTest.php
+++ b/app/tests/Unit/Components/VoteResultChartBarTest.php
@@ -14,21 +14,21 @@ it('contains no percentage value if it would be below 5%', function () {
 
 it('shows the correct thumb', function () {
     $view = $this->blade('<x-vote-result-chart-bar :value="10" :total="100" position="for" />');
-    expect($view)->toSee('thumb--for');
+    expect($view)->toHaveSelector('.thumb--for');
 
     $view = $this->blade('<x-vote-result-chart-bar :value="10" :total="100" position="against" />');
-    expect($view)->toSee('thumb--against');
+    expect($view)->toHaveSelector('.thumb--against');
 
     $view = $this->blade('<x-vote-result-chart-bar :value="10" :total="100" position="abstention" />');
-    expect($view)->toSee('thumb--abstention');
+    expect($view)->toHaveSelector('.thumb--abstention');
 });
 
 it('shows no thumb if percentage is below 10', function () {
     $view = $this->blade('<x-vote-result-chart-bar :value="9" :total="100" position="for" />');
-    expect($view)->not()->toSee('thumb');
+    expect($view)->not()->toHaveSelector('.thumb');
 });
 
 it('has the correct width depending on its percentage value', function () {
     $view = $this->blade('<x-vote-result-chart-bar :value="10" :total="100" position="for" />');
-    expect($view)->toSee('--ratio: 0.1');
+    expect($view)->toHaveSelector('.vote-result-chart__bar[style="--ratio: 0.1"]');
 });

--- a/app/tests/Unit/Components/VoteResultChartTest.php
+++ b/app/tests/Unit/Components/VoteResultChartTest.php
@@ -9,12 +9,10 @@ beforeEach(function () {
     $this->view = $this->blade('<x-vote-result-chart :stats=$stats />', ['stats' => $stats]);
 });
 
-it('renders three bars', function () {
-    expect($this->view)->toSeeInOrder([
-        'vote-result-chart__bar--for',
-        'vote-result-chart__bar--against',
-        'vote-result-chart__bar--abstention',
-    ]);
+it('renders three bars in correct order', function () {
+    expect($this->view)->toHaveSelector(
+        '.vote-result-chart__bar--for + .vote-result-chart__bar--against + .vote-result-chart__bar--abstention',
+    );
 });
 
 it('displays absolute numbers correctly', function () {


### PR DESCRIPTION
This adds two PHPUnit assertion methods and the respective Pest expectations to the two relevant classes `TestView` and `TestResponse`. An instance of `TestView` ist returned e.g. when we render an isolated Blade component, e.g. like this:

```php
$view = $this->blade('<x-thumb result="adopted" />');
```

An instance of `TestResponse` is returned when we send a response in our HTTP feature test, e.g. like this:

```php
$response = $this->get('/votes/1');
```

In both cases, it would be handy to be able to assert that a particular elements exists using CSS selectors, e.g. like this:

```php
$response->assertSelector(‘.thumb—adopted.thumb--circle’);
```

Right now, we work around this using `assertSee`, e.g. like this

```php
$response->assertSee(‘thumb--adopted thumb--circle’)
```

This works, but is prone to errors. It simply asserts that the string exists somewhere in the response. As a consequence, it will break if for example the order of classes in the `class` attribute changes, the above `assertSee` matches the first element, but not the second:

```html
<span class=“thumb thumb--adopted thumb--circle”>
<span class=“thumb thumb--circle thumb--adopted”>
```

Also, using `assertSee` does not allow for more complex assertions, e.g. to test for nested elements:

```html
<li class=“list-item”>
  <span class=“thumb thumb--adopted”></span>
</li>
```

This is now possible using the newly added assertions:

```php
$response->assertSelector(‘.list-item > .thumb.thumb—adopted’)
```

Apart from that, it’s also possible to assert that a selector matches an exact amount of elements and that a selector matches elements with a given text:

```php
// Expect 3 elements with the class `.thumb--adopted`
$response->assertSelector(‘.thumb--adopted’, 3);

// Expect 2 elements with class `.list-item__subtitle` contain text `Greens/EFA`
$response->assertSelectorText(‘.list-item__subtitle’, ‘Greens/EFA’, 2);
```

As our test framework Pest basically is only a wrapper around PHPUnit, providing a more intuitive interface to write tests, I implmented these as “standard” assertions first, then added the respective Pest expectations – i.e. we can use both in our tests like this:

```php
expect($response)->toHaveSelector(‘.thumb--adopted’);
expect($response)->toHaveSelectorWithText(‘.list-item’, ‘Greens/EFA’);
```

The assertions themselves are implemented using the `css-selector-converter` package. PHP has native DOM libraries to parse XML/HTML documents using xPath expressions. The basic idea is to first convert the CSS selector to an xPath expression using `css-selector-converter`, then use the native PHP DOM libraries to query the document using the resulting xPath selector.

Closes #280.