### PR TITLE
Add static page cache

### DIFF
--- a/ansible/roles/deployment/tasks/main.yml
+++ b/ansible/roles/deployment/tasks/main.yml
@@ -89,6 +89,11 @@
     minute: "*"
     job: "cd {{ epvotes.install_dir }}/app && php artisan schedule:run >> /dev/null 2>&1"
 
+- name: Clear static page cache
+  shell:
+    cmd: php artisan page-cache:clear
+    chdir: "{{ epvotes.install_dir }}/app"
+
 - name: Disable Laravel maintenance mode
   shell:
     cmd: php artisan up

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -4,6 +4,7 @@
 /public/css
 /public/js
 /public/mix-manifest.json
+/public/page-cache
 /storage/*.key
 /vendor
 .env

--- a/app/app/Http/Kernel.php
+++ b/app/app/Http/Kernel.php
@@ -37,6 +37,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \Silber\PageCache\Middleware\CacheResponse::class,
         ],
 
         'api' => [

--- a/app/composer.json
+++ b/app/composer.json
@@ -16,6 +16,7 @@
         "laravel/framework": "^8.0",
         "laravel/tinker": "^2.0",
         "sentry/sentry-laravel": "^2.4",
+        "silber/page-cache": "^1.0",
         "spatie/laravel-enum": "^2",
         "spatie/simple-excel": "^1.13",
         "spatie/url": "^2.0",

--- a/app/composer.lock
+++ b/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f642a721f0afc4074cb7ff0be6d0988",
+    "content-hash": "195cc883a1f5d51126584ab20a119665",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4238,6 +4238,69 @@
                 }
             ],
             "time": "2021-06-16T09:26:40+00:00"
+        },
+        {
+            "name": "silber/page-cache",
+            "version": "v1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JosephSilber/page-cache.git",
+                "reference": "cea67525d8407988d8fecfb0c87901546e39754c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JosephSilber/page-cache/zipball/cea67525d8407988d8fecfb0c87901546e39754c",
+                "reference": "cea67525d8407988d8fecfb0c87901546e39754c",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "5.0 - 5.8|^6.0|^7.0|^8.0",
+                "illuminate/filesystem": "5.0 - 5.8|^6.0|^7.0|^8.0",
+                "php": ">=5.5.9",
+                "symfony/http-foundation": "2.6 - 4|^5.0"
+            },
+            "require-dev": {
+                "illuminate/container": "5.0 - 5.8|^6.0|^7.0|^8.0",
+                "mockery/mockery": "^0.9.5",
+                "phpunit/phpunit": "^4.8",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "illuminate/console": "Allows clearing the cache via artisan"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Silber\\PageCache\\LaravelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Silber\\PageCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joseph Silber",
+                    "email": "contact@josephsilber.com"
+                }
+            ],
+            "description": "Caches responses as static files on disk for lightning fast page loads.",
+            "keywords": [
+                "cache",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/JosephSilber/page-cache/issues",
+                "source": "https://github.com/JosephSilber/page-cache/tree/v1.0.7"
+            },
+            "time": "2020-09-10T13:52:10+00:00"
         },
         {
             "name": "spatie/enum",
@@ -10843,5 +10906,5 @@
         "php": "^8"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/app/config/app.php
+++ b/app/config/app.php
@@ -165,6 +165,7 @@ return [
         /*
          * Package Service Providers...
          */
+        Silber\PageCache\LaravelServiceProvider::class,
 
         /*
          * Application Service Providers...

--- a/app/public/.htaccess
+++ b/app/public/.htaccess
@@ -14,6 +14,17 @@
     RewriteCond %{REQUEST_URI} (.+)/$
     RewriteRule ^ %1 [L,R=301]
 
+    # Serve Cached Page If Available...
+    RewriteCond %{REQUEST_URI} ^/?$
+    RewriteCond %{DOCUMENT_ROOT}/page-cache/pc__index__pc.html -f
+    RewriteRule .? page-cache/pc__index__pc.html [L]
+    RewriteCond %{DOCUMENT_ROOT}/page-cache%{REQUEST_URI}.html -f
+    RewriteRule . page-cache%{REQUEST_URI}.html [L]
+    RewriteCond %{DOCUMENT_ROOT}/page-cache%{REQUEST_URI}.json -f
+    RewriteRule . page-cache%{REQUEST_URI}.json [L]
+    RewriteCond %{DOCUMENT_ROOT}/page-cache%{REQUEST_URI}.xml -f
+    RewriteRule . page-cache%{REQUEST_URI}.xml [L]
+
     # Send Requests To Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
All our contents are 100% static & public, i.e. there’s no need to regenerate them on every request.

The `page-cache` package caches the response of GET requests in static HTML files on the file system. On subsequent requests, the webserver can directly serve these static pages, i.e. the webserver doesn't even need to pass on the request to PHP. For example, after requesting `/votes/1`, the following static directory structure will be created:

```
$ tree page-cache/
page-cache/
|-- pc__index__pc.html
`-- votes
    |-- 1.html
```

I’ve added a step to our Ansible deployment role to clear the cache on every deployment. We might also want to clear the cache for individual votes etc. whenever we re-scrape data for them.