### PR TITLE
Create avatar thumbnails

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -5,6 +5,9 @@ RUN apk --update add \
     autoconf \
     libressl-dev \
     libzip-dev \
+    libpng-dev \
+    libjpeg-turbo-dev \
+    libwebp-dev \
     bash \
     less \
     make \
@@ -13,12 +16,18 @@ RUN apk --update add \
 RUN pecl install pcov && docker-php-ext-enable pcov
 RUN docker-php-ext-enable pcov
 
+RUN docker-php-ext-configure gd \
+    --enable-gd \
+    --with-jpeg \
+    --with-webp
+
 RUN docker-php-ext-install \
     bcmath \
     ctype \
     zip \
     mysqli \
-    pdo_mysql
+    pdo_mysql \
+    gd
 
 RUN apk add nodejs npm
 

--- a/app/app/Actions/CreateMemberThumbnailAction.php
+++ b/app/app/Actions/CreateMemberThumbnailAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Actions;
+
+use App\Member;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Exception\NotReadableException;
+use Intervention\Image\Facades\Image;
+
+class CreateMemberThumbnailAction extends Action
+{
+    public function execute(Member $member): void
+    {
+        $url = "https://www.europarl.europa.eu/mepphoto/{$member->web_id}.jpg";
+
+        $width = 104;
+        $quality = 50;
+
+        $path = "members/{$member->id}-{$width}px.jpg";
+
+        try {
+            $thumb = Image::make($url)
+                ->widen($width)
+                ->crop($width, $width)
+                ->encode('jpg', $quality);
+
+            Storage::disk('public')->put($path, $thumb);
+        } catch (NotReadableException $exception) {
+            // It’s most likely that the parliament website returned a
+            // 404 error code when requesting the original image.
+        }
+    }
+}

--- a/app/app/Http/Controllers/VotingListsController.php
+++ b/app/app/Http/Controllers/VotingListsController.php
@@ -64,7 +64,7 @@ class VotingListsController extends Controller
     {
         $rows = $this->members($votingList)->map(function ($member) {
             return [
-                'member_id' => $member->member_id,
+                'member_id' => $member->id,
                 'last_name' => $member->last_name,
                 'first_name' => $member->first_name,
                 'group.abbreviation' => $member->group->abbreviation,
@@ -87,7 +87,10 @@ class VotingListsController extends Controller
             ->members()
             ->withGroupMembershipAt($votingList->date)
             ->with('group')
-            ->select('*')
+            // Select only specific attributes of joined tables
+            // as otherwise e.g. `group_memberships.id` would overwrite
+            // `members.id`.
+            ->select('members.*', 'votings.position', 'group_memberships.group_id')
             ->get();
     }
 }

--- a/app/app/Member.php
+++ b/app/app/Member.php
@@ -108,4 +108,9 @@ class Member extends Model
             $join->on('group_memberships.member_id', '=', 'members.id');
         });
     }
+
+    public function getThumbnailUrlAttribute(): string
+    {
+        return "/storage/members/{$this->id}-104px.jpg";
+    }
 }

--- a/app/composer.json
+++ b/app/composer.json
@@ -13,6 +13,7 @@
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
+        "intervention/image": "^2.6",
         "laravel/framework": "^8.0",
         "laravel/tinker": "^2.0",
         "sentry/sentry-laravel": "^2.4",

--- a/app/composer.lock
+++ b/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "195cc883a1f5d51126584ab20a119665",
+    "content-hash": "3f8e15392f40c331663f93c27690df9d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1719,6 +1719,90 @@
                 "source": "https://github.com/http-interop/http-factory-guzzle/tree/1.2.0"
             },
             "time": "2021-07-21T13:50:14+00:00"
+        },
+        {
+            "name": "intervention/image",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "0925f10b259679b5d8ca58f3a2add9255ffcda45"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/0925f10b259679b5d8ca58f3a2add9255ffcda45",
+                "reference": "0925f10b259679b5d8ca58f3a2add9255ffcda45",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "guzzlehttp/psr7": "~1.1 || ^2.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.2",
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^7.5.15"
+            },
+            "suggest": {
+                "ext-gd": "to use GD library based image processing.",
+                "ext-imagick": "to use Imagick based image processing.",
+                "intervention/imagecache": "Caching extension for the Intervention Image library"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Intervention\\Image\\ImageServiceProvider"
+                    ],
+                    "aliases": {
+                        "Image": "Intervention\\Image\\Facades\\Image"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src/Intervention/Image"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@olivervogel.com",
+                    "homepage": "http://olivervogel.com/"
+                }
+            ],
+            "description": "Image handling and manipulation library with support for Laravel integration",
+            "homepage": "http://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "laravel",
+                "thumbnail",
+                "watermark"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/image/issues",
+                "source": "https://github.com/Intervention/image/tree/2.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/interventionphp",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-22T14:31:53+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/app/config/app.php
+++ b/app/config/app.php
@@ -166,6 +166,7 @@ return [
          * Package Service Providers...
          */
         Silber\PageCache\LaravelServiceProvider::class,
+        Intervention\Image\ImageServiceProvider::class,
 
         /*
          * Application Service Providers...
@@ -227,6 +228,8 @@ return [
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
+
+        'Image' => Intervention\Image\Facades\Image::class,
 
     ],
 

--- a/app/config/image.php
+++ b/app/config/image.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Image Driver
+    |--------------------------------------------------------------------------
+    |
+    | Intervention Image supports "GD Library" and "Imagick" to process images
+    | internally. You may choose one of them according to your PHP
+    | configuration. By default PHP's "GD Library" implementation is used.
+    |
+    | Supported: "gd", "imagick"
+    |
+    */
+
+    'driver' => 'gd',
+
+];

--- a/app/public/.htaccess
+++ b/app/public/.htaccess
@@ -30,3 +30,15 @@
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
 </IfModule>
+
+<IfModule mod_expires.c>
+    ExpiresActive on
+
+    ExpiresByType image/jpg "access plus 60 days"
+    ExpiresByType image/jpeg "access plus 60 days"
+    ExpiresByType image/png "access plus 60 days"
+    ExpiresByType image/webp "access plus 60 days"
+    ExpiresByType text/css "access plus 6 months"
+    ExpiresByType text/javascript "access plus 6 months"
+    ExpiresByType application/javascript "access plus 6 months"
+</IfModule>

--- a/app/resources/views/components/member-list-item.blade.php
+++ b/app/resources/views/components/member-list-item.blade.php
@@ -4,7 +4,7 @@
 ])
 
 <x-list-item
-    avatar-url="https://www.europarl.europa.eu/mepphoto/{{ $member->web_id }}.jpg"
+    :avatar-url="$member->thumbnail_url"
     :title="$member->full_name"
     :subtitle="$member->group->abbreviation.' · '.$member->country->label"
     :position="$position"

--- a/app/routes/console.php
+++ b/app/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\CreateMemberThumbnailAction;
 use App\Actions\GenerateVoteSharePicAction;
 use App\Actions\MatchVotesAndVotingListsAction;
 use App\Actions\ScrapeMemberGroupsAction;
@@ -10,7 +11,6 @@ use App\Actions\ScrapeVotingListsAction;
 use App\Member;
 use App\Term;
 use App\VoteCollection;
-use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 
@@ -48,6 +48,20 @@ Artisan::command('scrape:members-info', function (ScrapeMemberInfoAction $action
 
     $this->output->writeln('');
 })->describe('Scrape and save info for all saved members.');
+
+Artisan::command('scrape:members-photos', function (CreateMemberThumbnailAction $action) {
+    $allMembers = Member::all();
+    $membersCount = $allMembers->count();
+
+    foreach ($allMembers as $index => $member) {
+        $progress = ($index + 1).'/'.$membersCount;
+        $this->output->write("\r<info>Creating thumbnail for member: {$progress}</info>");
+
+        $action->execute($member);
+    }
+
+    $this->output->writeln('');
+});
 
 Artisan::command('scrape:members-groups {--term=}', function (
     int $term,


### PR DESCRIPTION
Currently, we embed photos of MEPs directly from the Parliament’s website. This is unfortunate for two reasons:

1. Hotlinking is usually unwanted by the host of the media as it increases traffic cost etc.

2. The browser has to open a connection to a separate host, increasing loading times. More importantly, the original images are way larger than what we actually display. If we create thumbnails in the correct size, we can reduce file sizes for the individual member photos from ~50kB to 2-3kB.